### PR TITLE
Add minimal frontend and instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,47 @@
 # GraphDB-wikidata
+
+This project contains a Rust based graph database server. The repository does not ship a GUI by default, so a small HTML frontend is included under the `frontend/` directory.
+
+## Requirements
+
+- Rust toolchain (for building and running the server)
+- A browser to open the frontend
+
+## Building the Server
+
+From the project root run:
+
+```bash
+cargo build --release
+```
+
+## Creating a Database
+
+Prepare a Wikidata JSON dump and build the database:
+
+```bash
+cargo run --release -- --database-dir wikidata create-db --file /path/to/wikidata.json
+```
+
+## Starting the Server
+
+Launch the API server on port `8005` (default):
+
+```bash
+cargo run --release -- --database-dir wikidata server --port 8005
+```
+
+The server exposes a `/query` endpoint and allows any origin via CORS so it can be accessed from a browser.
+
+## Running the Frontend
+
+A simple frontend is provided in `frontend/`. Start a static file server in that directory, e.g.:
+
+```bash
+cd frontend
+python3 -m http.server 8080
+```
+
+Then open `http://localhost:8080` in your browser. Enter a SPARQL query and submit it; the frontend will send it to `http://127.0.0.1:8005/query` and display the JSON result.
+
+> The previously used remote GUI at `wikidata.bonxai.org` is currently unavailable. This local frontend serves as a minimal replacement.

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -1,0 +1,20 @@
+const form = document.getElementById('query-form');
+const resultEl = document.getElementById('result');
+
+form.addEventListener('submit', async (e) => {
+  e.preventDefault();
+  const query = document.getElementById('query').value;
+  resultEl.textContent = 'Running...';
+  try {
+    const resp = await fetch(`http://127.0.0.1:8005/query?query=${encodeURIComponent(query)}`);
+    if (!resp.ok) {
+      const text = await resp.text();
+      resultEl.textContent = 'Error: ' + resp.status + '\n' + text;
+      return;
+    }
+    const json = await resp.json();
+    resultEl.textContent = JSON.stringify(json, null, 2);
+  } catch (err) {
+    resultEl.textContent = 'Network error: ' + err;
+  }
+});

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>GraphDB Frontend</title>
+<style>
+body { font-family: sans-serif; margin: 2em; }
+textarea { width: 100%; height: 150px; }
+pre { white-space: pre-wrap; word-wrap: break-word; background: #f0f0f0; padding: 1em; }
+</style>
+</head>
+<body>
+<h1>GraphDB Frontend</h1>
+<form id="query-form">
+<label for="query">SPARQL Query:</label><br>
+<textarea id="query" placeholder="Enter SPARQL query here"></textarea><br>
+<button type="submit">Run Query</button>
+</form>
+<h2>Result</h2>
+<pre id="result"></pre>
+<script src="app.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a simple web UI in `frontend/`
- document build and usage steps in README

## Testing
- `cargo check`
- `cargo test --no-run` *(fails: took too long and produced many warnings)*

------
https://chatgpt.com/codex/tasks/task_e_684315e3d360832a98b29b6d9ef5cf95